### PR TITLE
build: add CA certificates and Clang tools

### DIFF
--- a/build/ubuntu-bionic/Dockerfile
+++ b/build/ubuntu-bionic/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       sudo less nano vim \
-      git curl wget \
+      git curl wget ca-certificates \
       tar unzip \
       build-essential \
-      clang gcc \
-      clang-format \
+      clang clang-7 gcc gcc-8 \
+      clang-format clang-format-7 clang-tidy-7 \
       gdb lldb elfutils strace \
       libssl-dev \
  && apt-get -y autoremove && apt-get -y clean \


### PR DESCRIPTION
CA certificates are required to be able to use HTTPS transport in various tools (like git). Also add more recent versions of compilers and Clang tools.