### PR TITLE
android-build: update platform

### DIFF
--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -1,49 +1,43 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo wget curl unzip git \
-        build-essential ninja-build default-jdk && \
+# System dependencies. Android SDK requires Java 8, it does not work with Java 11.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        sudo wget curl unzip git \
+        build-essential ninja-build openjdk-8-jdk && \
     apt-get -y autoremove && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Golang
+# Golang (see https://golang.org/dl/)
 RUN wget -O /go.tar.gz \
-        https://redirector.gvt1.com/edgedl/go/go1.9.2.linux-amd64.tar.gz && \
+        https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /go.tar.gz && \
     rm /go.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
+# Regular user account
 RUN useradd --groups sudo --create-home --shell /bin/bash user && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     mkdir /projects && chown user:user /projects
 USER user
 
-# Android SDK and NDK
+# Android SDK and NDK (see https://developer.android.com/studio/#downloads)
 RUN wget -O ~/sdk-tools-linux.zip \
-      https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip && \
+      https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     mkdir ~/android-sdk && \
     cd ~/android-sdk && \
     unzip ~/sdk-tools-linux.zip && \
     rm ~/sdk-tools-linux.zip && \
     yes | ~/android-sdk/tools/bin/sdkmanager --licenses && \
-    yes | ~/android-sdk/tools/bin/sdkmanager --update && \
-    ~/android-sdk/tools/bin/sdkmanager 'build-tools;27.0.3' 'cmake;3.6.4111459' 'platforms;android-27' 'ndk-bundle' 'emulator' && \
-    cd ~/android-sdk/ndk-bundle/toolchains && \
-    ln -s aarch64-linux-android-4.9 mips64el-linux-android && \
-    ln -s arm-linux-androideabi-4.9 mipsel-linux-android
-
+    ~/android-sdk/tools/bin/sdkmanager \
+        'build-tools;28.0.3' \
+        'cmake;3.6.4111459' \
+        'platforms;android-28' \
+        'platform-tools' \
+        'ndk-bundle' \
+        'emulator' \
+        'system-images;android-24;default;armeabi-v7a'
 ENV ANDROID_HOME=/home/user/android-sdk
-
-
-# CMake
-RUN wget -O ~/cmake.sh \
-        https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.sh && \
-    chmod u+x ~/cmake.sh && \
-    mkdir ~/cmake && \
-    ~/cmake.sh --skip-license --prefix=/home/user/cmake && \
-    rm ~/cmake.sh
-
-ENV PATH=/home/user/cmake/bin:$PATH
+ENV PATH=$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools
 
 WORKDIR /projects


### PR DESCRIPTION
Update various bits of Android build platform so that we are able to build, test, and deploy for modern Android devices.

The image is still based off Ubuntu 16.04 LTS which is supported until April 2021, so that's good enough. Base system toolchain is not really important since Android SDK includes its own.

We are now explicitly installing OpenJDK 8 to ease eventual transition to the next Ubuntu LTS. Currently Android SDK manager does not work with Java 11 from Ubuntu repositories, so we have to use the older version. Ubuntu 16.04 has Java 8 as default while Ubuntu 18.04 installs Java 11.

While we're here, update Go binaries to the current stable version 1.13. It's not a critical component (just some codegen for BoringSSL), but let's keep the platform updated. Also, use the canonical download link.

Finally, install current stable version of Android SDK and NDK. This includes various bug fixes. For example, it's no longer necessary to maintain hacks for MIPS. Also, preinstall newer versions of build tools, Android platform, and system image for testing.

We don't need to install standalone CMake. Android SDK includes and uses its own CMake binary.

----

New Android SDK is quite big. The image goes up to 7.73 GB from 4.82 GB used by `2019.01` tag. Blame Google for the bloat 🤷‍♂